### PR TITLE
Remove redundant import

### DIFF
--- a/startup.py
+++ b/startup.py
@@ -5,7 +5,6 @@ import random
 import re
 import json
 import time
-import os.path
 import os
 import socket
 import requests


### PR DESCRIPTION
Hello @schollz,

I have noticed that there is this statement on the `startup.py` file:

```python
import os.path
import os
```

Only with importing the `os` you don't need the `os.path`

I created the PR just for saving you :clock1:, I hope it is not rude making this PR without even asking first.

Regards.